### PR TITLE
Remove scrapy and django from install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,5 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Topic :: Utilities',
     ],
-    install_requires=[
-        'Scrapy>=0.24.5',
-        'Django',
-    ],
+    requires=['scrapy (>=0.24.5)', 'django'],
 )


### PR DESCRIPTION
This prevents unintended upgrades of Scrapy or Django when user runs 
`pip install -U scrapy-djangoitem`.

I don't think anybody will want to install Django or Scrapy by installing scrapy-djangoitem anyways.
